### PR TITLE
Limpa cookie de sessão ao utilizar sessão expirada

### DIFF
--- a/infra/controller.js
+++ b/infra/controller.js
@@ -15,11 +15,12 @@ function onNoMatchHandler(request, response) {
 }
 
 function onErrorHandler(error, request, response) {
-  if (
-    error instanceof ValidationError ||
-    error instanceof NotFoundError ||
-    error instanceof UnauthorizedError
-  ) {
+  if (error instanceof ValidationError || error instanceof NotFoundError) {
+    return response.status(error.statusCode).json(error);
+  }
+
+  if (error instanceof UnauthorizedError) {
+    clearSessionCookie(response);
     return response.status(error.statusCode).json(error);
   }
 

--- a/models/session.js
+++ b/models/session.js
@@ -63,7 +63,7 @@ async function create(userId) {
 async function renew(sessionId) {
   const expiresAt = new Date(Date.now() + EXPIRATION_IN_MILLISECONDS);
 
-  const renewedSessionObject = runUpdateQuery(sessionId, expiresAt);
+  const renewedSessionObject = await runUpdateQuery(sessionId, expiresAt);
   return renewedSessionObject;
 
   async function runUpdateQuery(sessionId, expiresAt) {

--- a/tests/integration/api/v1/user/get.test.js
+++ b/tests/integration/api/v1/user/get.test.js
@@ -154,6 +154,19 @@ describe("GET /api/v1/user", () => {
         action: "Verifique se este usuário está logado e tente novamente.",
         status_code: 401,
       });
+
+      // Set-Cookie assertions
+      const parsedSetCookie = setCookieParser(response, {
+        map: true,
+      });
+
+      expect(parsedSetCookie.session_id).toEqual({
+        name: "session_id",
+        value: "invalid",
+        maxAge: -1,
+        path: "/",
+        httpOnly: true,
+      });
     });
 
     test("With expired session", async () => {
@@ -184,6 +197,19 @@ describe("GET /api/v1/user", () => {
         message: "Usuário não possui sessão ativa.",
         action: "Verifique se este usuário está logado e tente novamente.",
         status_code: 401,
+      });
+
+      // Set-Cookie assertions
+      const parsedSetCookie = setCookieParser(response, {
+        map: true,
+      });
+
+      expect(parsedSetCookie.session_id).toEqual({
+        name: "session_id",
+        value: "invalid",
+        maxAge: -1,
+        path: "/",
+        httpOnly: true,
       });
     });
   });


### PR DESCRIPTION
Este Pull Request é composto por dois commits:

a315bdf2f3f86012e0f50f12cde3961915275914
Este commit, dentro do `controller.js` na parte onde ele recebe os erros (`onErrorHandler`), separa em sua própria condicional o que é um `UnauthorizedError` para que neste caso seja devolvido um cabeçalho `Set-Cookie` com o objetivo de limpar o `session_id` do client.

ccaf6235f0020ac0a7e71e8a71651c687e71d902
Este commit adiciona a falta de um `await` dentro do `session.renew()` que foi apontado por @alankewem através [deste comentário](https://github.com/filipedeschamps/clone-tabnews/pull/55#pullrequestreview-3089160435) no PR #55.