### PR TITLE
Corrige erro intermitente no teste `activations/[token_id]/patch.test.js`

### DIFF
--- a/tests/integration/api/v1/activations/[token_id]/patch.test.js
+++ b/tests/integration/api/v1/activations/[token_id]/patch.test.js
@@ -131,10 +131,16 @@ describe("PATCH /api/v1/activations/[token_id]", () => {
       const expiresAt = new Date(responseBody.expires_at);
       const createdAt = new Date(responseBody.created_at);
 
-      expiresAt.setMilliseconds(0);
-      createdAt.setMilliseconds(0);
+      const expectedExpiresAt = new Date(
+        createdAt.getTime() + activation.EXPIRATION_IN_MILLISECONDS,
+      );
 
-      expect(expiresAt - createdAt).toBe(activation.EXPIRATION_IN_MILLISECONDS);
+      expect(expectedExpiresAt.getTime()).toBeGreaterThanOrEqual(
+        expiresAt.getTime(),
+      );
+      expect(
+        expectedExpiresAt.getTime() - expiresAt.getTime(),
+      ).toBeLessThanOrEqual(100);
 
       const activatedUser = await user.findOneById(responseBody.user_id);
       expect(activatedUser.features).toEqual([
@@ -166,6 +172,34 @@ describe("PATCH /api/v1/activations/[token_id]", () => {
         action: "Entre em contato com o suporte.",
         status_code: 403,
       });
+    });
+
+    test("setMilliseconds(0) with toBe fails on race condition", () => {
+      const expiresAt = new Date("2026-01-01T00:15:00.999Z");
+      const createdAt = new Date("2026-01-01T00:00:01.001Z");
+
+      expiresAt.setMilliseconds(0);
+      createdAt.setMilliseconds(0);
+
+      expect(expiresAt - createdAt).not.toBe(
+        activation.EXPIRATION_IN_MILLISECONDS,
+      );
+    });
+
+    test("comparing from createdAt resolves the race condition", () => {
+      const expiresAt = new Date("2026-01-01T00:15:00.999Z");
+      const createdAt = new Date("2026-01-01T00:00:01.001Z");
+
+      const expectedExpiresAt = new Date(
+        createdAt.getTime() + activation.EXPIRATION_IN_MILLISECONDS,
+      );
+
+      expect(expectedExpiresAt.getTime()).toBeGreaterThanOrEqual(
+        expiresAt.getTime(),
+      );
+      expect(
+        expectedExpiresAt.getTime() - expiresAt.getTime(),
+      ).toBeLessThanOrEqual(100);
     });
   });
 


### PR DESCRIPTION
Este PR foi aberto com base [neste comentário](https://curso.dev/alunos/rafamaia23/4f953f46-742b-4f2e-b5eb-70bbebb9ea04) do aluno [rafamaia23](https://curso.dev/alunos/rafamaia23).

---

No arquivo `tests/integration/api/v1/activations/[token_id]/patch.test.js`, o teste `PATCH /api/v1/activations/[token_id] -> Anonymous user -> With valid token` falhava intermitentemente com: 

```bash
Expected: 900000
Received: 899000
```

O erro acontecia na linha 137:

```js
expect(expiresAt - createdAt).toBe(activation.EXPIRATION_IN_MILLISECONDS)
```

### Motivo

O `expires_at` é calculado no JavaScript, no arquivo `activation.js`, na linha 45, onde `EXPIRATION_IN_MILLISECONDS` é igual a `900000` (15 minutos):

```js
const expiresAt = new Date(Date.now() + EXPIRATION_IN_MILLISECONDS); 
```

Já o `created_at` é definido pelo PostgreSQL com o método `timezone('utc', now())`. 

Entre os dois há uma latência de alguns ms, ou seja, o tempo de enviar a query e o banco processá-la. Quando o `Date.now()` cai no **.999ms** de um segundo e o INSERT do banco executa no **.001ms** do segundo seguinte, o `setMilliseconds(0)` no teste zera as frações de ambos:

```
expires_at → 00:15:00.999Z  → após setMilliseconds(0) → 00:15:00.000Z
created_at → 00:00:01.001Z  → após setMilliseconds(0) → 00:00:01.000Z
```

Diferença = 14min59s = **899000ms** em vez de 900000ms (perdeu 1s inteiro). É intermitente porque só ocorre quando o timestamp do JS está no final do segundo e o INSERT cruza a virada.

---

Dois testes foram criados em `patch.test.js` (que podem ser removidos depois):

**1. Prova que o bug existe**

```js
test("setMilliseconds(0) + toBe exato quebra na virada do segundo", () => {
  const expiresAt = new Date("2026-01-01T00:15:00.999Z");
  const createdAt = new Date("2026-01-01T00:00:01.001Z");

  expiresAt.setMilliseconds(0);
  createdAt.setMilliseconds(0);

  expect(expiresAt - createdAt).not.toBe(activation.EXPIRATION_IN_MILLISECONDS);
});
```

**2. Prova que a correção funciona**

```js
test("corrigido sem setMilliseconds(0)", () => {
  const expiresAt = new Date("2026-01-01T00:15:00.999Z");
  const createdAt = new Date("2026-01-01T00:00:01.001Z");

  const expectedExpiresAt = new Date(
    createdAt.getTime() + activation.EXPIRATION_IN_MILLISECONDS,
  );

  expect(expectedExpiresAt.getTime()).toBeGreaterThanOrEqual(
    expiresAt.getTime(),
  );
  expect(expectedExpiresAt.getTime() - expiresAt.getTime()).toBeLessThanOrEqual(
    100,
  );
});
```

---

### Correção

Em vez de tentar "limpar" os timestamps com `setMilliseconds(0)` e exigir diferença exata, a nova asserção valida a **relação** entre eles. O `created_at` foi definido pelo banco **depois** do `Date.now()` no JS, então `created_at + 15min` é sempre >= `expires_at`, com diferença de no máximo alguns ms (a latência entre o cálculo JS e o INSERT).